### PR TITLE
HM-4151

### DIFF
--- a/ansible/sample_production/ansible.cfg
+++ b/ansible/sample_production/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+
+inventory = ./inventory.ini
+host_key_checking = True

--- a/ansible/sample_production/files/initiator_random_write.fio
+++ b/ansible/sample_production/files/initiator_random_write.fio
@@ -1,0 +1,14 @@
+[write-verify]
+name=Write Verify Job
+description="Randomly writes to a directory and verifies the write"
+ioengine=libaio
+iodepth=4
+bs=16k
+direct=1
+rw=randwrite
+verify=crc32c
+filesize=128k
+time_based
+runtime=10m
+
+

--- a/ansible/sample_production/group_vars/all
+++ b/ansible/sample_production/group_vars/all
@@ -1,0 +1,8 @@
+# read from OS vars
+api_client: "{{ ansible_env.API_CLIENT }}"
+priv_key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+
+# read from value/file
+#api_client: "pure1:apikey:123456789"
+#priv_key_file: "/home/user/key.pem"
+

--- a/ansible/sample_production/group_vars/workloads.yml
+++ b/ansible/sample_production/group_vars/workloads.yml
@@ -1,0 +1,55 @@
+prefix_disk: "3624a9370"
+
+tenant_space:
+  - name: db_tenant_space
+    display_name: oracle-db
+    tenant: oracle_dbas
+ 
+placement_groups:
+  - name: pg1
+    display_name: pg1
+    storage_service: flash_performance
+    tenant: oracle_dbas
+    tenant_space: db_tenant_space
+    region: region1
+    availability_zone: az1
+    
+
+volumes:
+  - name: data_vol1
+    display_name: data_vol1
+    size: 500G
+    storage_class: db_high_performance
+    tenant: oracle_dbas
+    tenant_space: db_tenant_space
+    placement_group: pg1
+    host_access_policies: ["initiatorserver1"]
+    mount_path: /mnt/data_vol1
+  - name: data_vol2
+    display_name: data_vol2
+    size: 500G
+    storage_class: db_standard
+    tenant: oracle_dbas
+    tenant_space: db_tenant_space
+    placement_group: pg1
+    host_access_policies: ["initiatorserver2", "initiatorserver3"]
+    mount_path: /mnt/data_vol2
+  - name: log_vol
+    display_name: log_vol
+    size: 500G
+    storage_class: db_standard
+    tenant: oracle_dbas
+    tenant_space: db_tenant_space
+    placement_group: pg1
+    host_access_policies: ["initiatorserver1", "initiatorserver3"]
+    mount_path: /mnt/log_vol
+  - name: config_vol
+    display_name: config_vol
+    size: 500G
+    tenant: oracle_dbas
+    tenant_space: db_tenant_space
+    storage_class: db_standard
+    placement_group: pg1
+    host_access_policies: ["initiatorserver2"]
+    mount_path: /mnt/config_vol
+

--- a/ansible/sample_production/host_vars/initiatorserver1.yml
+++ b/ansible/sample_production/host_vars/initiatorserver1.yml
@@ -1,0 +1,4 @@
+---
+ansible_user: username
+ansible_host: 192.168.1.100
+ansible_ssh_private_key_file: ~/.ssh/id_rsa

--- a/ansible/sample_production/host_vars/initiatorserver2.yml
+++ b/ansible/sample_production/host_vars/initiatorserver2.yml
@@ -1,0 +1,4 @@
+---
+ansible_user: username
+ansible_host: 192.168.1.101
+ansible_ssh_private_key_file: ~/.ssh/id_rsa

--- a/ansible/sample_production/host_vars/initiatorserver3.yml
+++ b/ansible/sample_production/host_vars/initiatorserver3.yml
@@ -1,0 +1,4 @@
+---
+ansible_user: username
+ansible_host: 192.168.1.102
+ansible_ssh_private_key_file: ~/.ssh/id_rsa

--- a/ansible/sample_production/inventory.ini
+++ b/ansible/sample_production/inventory.ini
@@ -1,0 +1,5 @@
+
+[Initiators_Hosts]
+initiatorserver1
+initiatorserver2
+initiatorserver3 

--- a/ansible/sample_production/setup_workloads.yml
+++ b/ansible/sample_production/setup_workloads.yml
@@ -1,0 +1,215 @@
+---
+- hosts: Initiators_Hosts
+
+  become: true
+  tasks: 
+
+    - name: Obtain IQN from Initiators_Hosts
+      shell: cat /etc/iscsi/initiatorname.iscsi | grep "^InitiatorName=iqn" | awk -F'=' '{print $2}'
+      register: iqn
+
+    - name: IQN Results
+      debug:
+        msg: 
+        - "Inventory Hostname: {{inventory_hostname}}"
+        - "Hostname: {{ansible_hostname}}"
+        - "IQN: {{iqn.stdout}}"
+   
+- hosts: localhost
+
+  tasks:
+    - include_vars: group_vars/workloads.yml
+    
+    - set_fact:
+        iqn_data: []
+        map_volumes: {}
+
+    - name: Check private key exists
+      stat:
+        path: "{{ priv_key_file }}"
+      register: result
+
+    - name: End run if missing private key
+      meta: end_play
+      when: (result.stat.isreg is undefined) or (not result.stat.isreg)
+
+    - name: Create IQN/Hostname dictionary
+      set_fact: 
+        iqn_data: "{{ iqn_data|default({}) + [ {'hostname':item, 'iqn':(hostvars[item]['iqn'].stdout)} ] }}"
+      with_items:
+        - "{{ groups['Initiators_Hosts'] }}"
+
+    - name: Create host access policy
+      purestorage.fusion.fusion_hap:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        state: "present"
+        name: "{{ item.hostname }}"
+        display_name: "{{ item.hostname }}"
+        personality: "linux"
+        iqn: "{{ item.iqn }}"
+      with_items: "{{iqn_data}}"
+      when: item.iqn != ""
+
+    - name: Create new tenant space(s)
+      purestorage.fusion.fusion_ts:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        state: "present"
+        name: "{{ item.name }}"
+        display_name: "{{ item.display_name }}"
+        tenant: "{{ item.tenant }}"
+      loop: "{{ tenant_space }}"
+
+
+    - name: Create new placement group(s)
+      purestorage.fusion.fusion_pg:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        state: "present" # or absent
+        name: "{{ item.name }}"
+        display_name: "{{ item.display_name }}"
+        tenant: "{{ item.tenant }}"
+        tenant_space: "{{ item.tenant_space }}"
+        availability_zone: "{{ item.availability_zone }}"
+        region: "{{ item.region }}"
+      loop: "{{ placement_groups }}"
+
+    - name: Create new volume(s)
+      purestorage.fusion.fusion_volume:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        state: "present" # or absent
+        name: "{{ item.name }}"
+        display_name: "{{ item.display_name }}"
+        size: "{{ item.size }}"
+        storage_class: "{{ item.storage_class }}"
+        tenant: "{{ item.tenant }}"
+        tenant_space: "{{ item.tenant_space }}"
+        placement_group: "{{ item.placement_group }}"
+        hosts: "{{ item.host_access_policies }}"
+      loop: "{{ volumes }}"
+    
+    - name: Get Volumes info
+      purestorage.fusion.fusion_info:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        gather_subset: volumes
+      register: fusion_info
+
+    - name: Map Volumes and Serial ID
+      set_fact:
+        map_volumes: >-
+              {{ map_volumes|combine(
+              { ((fusion_info['fusion_info']['volumes'][item]['name']).lower()) : (prefix_disk + (fusion_info['fusion_info']['volumes'][item]['serial_number']).lower()) }
+              ) }}
+      loop: "{{ fusion_info['fusion_info']['volumes'].keys() }}"
+
+    - name: Get Purestorage Storage Endpoints
+      purestorage.fusion.fusion_info:
+        gather_subset: storage_endpoints
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+      register: reg_fusion_info
+
+- hosts: Initiators_Hosts
+  become: true
+  tasks: 
+    - set_fact:
+        valid_volumes: {}
+        devices_list: {}
+        iscsi_interfaces: []
+        list_ip: []
+        reg_fusion_info: "{{ hostvars['localhost']['reg_fusion_info'] }}"
+
+
+    - name: Obtain list of volumes to mount
+      set_fact:
+        valid_volumes: "{{ valid_volumes|combine( {item.name: item.mount_path} ) }}"
+      with_items: "{{ hostvars['localhost']['volumes'] }}" 
+      when: inventory_hostname in item.host_access_policies
+
+    - debug: msg="{{ valid_volumes }}" 
+
+    - name: Parse volume, mount path and volume id
+      set_fact:
+        devices_list: "{{ devices_list|combine( { valid_volumes[item.key]:item.value } ) }}"
+      with_dict: "{{ hostvars['localhost']['map_volumes'] }}"
+      when: item.key in valid_volumes.keys()
+
+    - debug:
+       msg:
+        - "Mount: /dev/mapper/{{ item.value }}"
+        - "On: {{ item.key }}"
+      with_dict: "{{ devices_list }}"
+
+    - name: Get a list of iscsi_interfaces
+      set_fact:
+        iscsi_interfaces: "{{ iscsi_interfaces + [reg_fusion_info['fusion_info']['storage_endpoints'][item]['iscsi_interfaces']] }}"
+      with_items: "{{ reg_fusion_info['fusion_info']['storage_endpoints'].keys() }}"
+
+    - name: Extract IP from iscsi_interfaces
+      set_fact:
+        list_ip: "{{ list_ip + [item['address'].split('/')[0]] }}"
+      with_items: "{{ iscsi_interfaces }}"
+
+    - name: "Perform a discovery and show available target nodes"
+      community.general.open_iscsi:
+        show_nodes: true
+        discover: true
+        ip: "{{ item }}"
+      with_items: "{{ list_ip }}"
+      register: discover_devices
+
+    - set_fact:
+        iscsi_target: "{{ discover_devices['results'][0]['nodes'][0] }}"
+
+    - name: Connect to the named target
+      community.general.open_iscsi:
+        login: true
+        target: "{{ iscsi_target }}"
+
+    - name: Create a primary partition
+      community.general.parted:
+        device: "/dev/mapper/{{item.key}}"
+        number: 1
+        state: present
+      with_dict: "{{ devices_list }}"
+
+    - name: Create/check ext4 partition
+      community.general.filesystem:
+        fstype: ext4
+        dev: "/dev/mapper/{{item.key}}-part1"
+      with_dict: "{{ devices_list }}"
+
+    - name: Creates directory for mountpoints
+      file:
+        path: "{{item.value}}"
+        state: directory
+      with_dict: "{{ devices_list }}"
+
+    - name: Mount volumes
+      ansible.posix.mount:
+        path: "{{item.value}}"
+        src: "/dev/mapper/{{item.key}}-part1"
+        fstype: ext4
+        state: mounted
+      with_dict: "{{ devices_list }}"
+
+    - name: Install fio
+      ansible.builtin.package:
+        name: fio
+        state: present
+
+    - name: Copy initiator_random_write.fio
+      ansible.builtin.copy:
+        src: "./files/initiator_random_write.fio"
+        dest: "/tmp/initiator_random_write.fio"
+
+    - name: Run FIO process
+      command: "chdir={{item.mount_path}} fio /tmp/initiator_random_write.fio"
+      with_items: "{{ hostvars['localhost']['volumes'] }}"
+      register: ps
+      
+    - name: FIO Results
+      debug: var=ps.stdout_lines

--- a/ansible/simple/create_tenant_space.yml
+++ b/ansible/simple/create_tenant_space.yml
@@ -1,0 +1,11 @@
+---
+- hosts: localhost
+  tasks:
+
+  - name: Create new tenant space db_tenant_space for tenant_name
+    purestorage.fusion.fusion_ts:
+      app_id: "{{ ansible_env.API_CLIENT}}"
+      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
+      state: "present" # or absent
+      name: "db_tenant_space"
+      tenant: "tenant_name"

--- a/ansible/simple/setup_workloads.yml
+++ b/ansible/simple/setup_workloads.yml
@@ -1,0 +1,70 @@
+---
+- hosts: localhost
+  # This playbook create:
+
+  # *- Tenant space: db_tenant_space
+  # *- Placement Group: pg1
+  # *- AIX host access policy: customer_host_access
+  # *- volume: data_vol1
+  # *- volume: data_vol2
+
+  # require:
+  # *- Storage class: db_high_performance
+  # *- Tenant: oracle_dbas
+  # *- Region: region1
+
+  tasks:
+
+  - name: Create new tenant space db_tenant_space for oracle_dbas
+    purestorage.fusion.fusion_ts:
+      app_id: "{{ ansible_env.API_CLIENT}}"
+      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
+      name: "db_tenant_space"
+      tenant: "oracle_dbas"
+      state: "present" # or absent
+
+  - name: Create new placement group named pg1
+    purestorage.fusion.fusion_pg:
+      app_id: "{{ ansible_env.API_CLIENT}}"
+      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
+      name: "pg1"
+      tenant: "oracle_dbas"
+      tenant_space: "db_tenant_space"
+      region: "region1"
+      availability_zone: "az1"
+      state: "present" # or absent
+
+  - name: Create new host access policy
+    purestorage.fusion.fusion_hap:
+      app_id: "{{ ansible_env.API_CLIENT}}"
+      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
+      name: "customer_host_access"
+      personality: "linux"
+      iqn: "iqn.1994-05.com.redhat:9dd57693efb"
+      state: "present" # or absent
+
+  - name: Create new volume named data_vol1 in storage_class db_high_performance
+    purestorage.fusion.fusion_volume:
+      app_id: "{{ ansible_env.API_CLIENT}}"
+      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
+      name: "data_vol1"
+      storage_class: "db_high_performance"
+      size: "500G" # Volume size in M, G, T or P units.
+      tenant: "oracle_dbas"
+      tenant_space: "db_tenant_space"
+      placement_group: "pg1"
+      hosts: "customer_host_access"
+      state: "present" # or absent
+
+  - name: Create new volume named data_vol2 in storage_class db_high_performance
+    purestorage.fusion.fusion_volume:
+      app_id: "{{ ansible_env.API_CLIENT}}"
+      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
+      name: "data_vol2"
+      storage_class: "db_high_performance"
+      size: "500G" # Volume size in M, G, T or P units.
+      tenant: "oracle_dbas"
+      tenant_space: "db_tenant_space"
+      placement_group: "pg1"
+      hosts: "customer_host_access"
+      state: "present" # or absent


### PR DESCRIPTION
-    Allow user to create a set of volumes a tenant-space with specified storage and protection policies
 -   Optionally allow user to create a new tenant-space
  -  Allow user to specify a set of initiators that will be consuming these volumes
-    Create host access policies and attach them to volumes to allow these initiators to perform I/O on these volumes
 -   Allow user to specify the directories on each initiator to mount these volumes
 
 
 - Reach out to the initiators to configure them to mount these volumes over iSCSI
- Install and run fio on these volumes as Proof-of-concept