### PR TITLE
HM-4149-Consumers:  setup, list and teardown

### DIFF
--- a/ansible/sample_production/group_vars/consumer.yml
+++ b/ansible/sample_production/group_vars/consumer.yml
@@ -1,0 +1,12 @@
+workdir: "keys"
+key_size: 2048
+
+tenants:
+  - name: tenant_test_1
+    display_name: tenant_test_1
+
+  - name: tenant_test_2
+    display_name: tenant_test_2
+
+  - name: tenant_test_3
+    display_name: tenant_test_3

--- a/ansible/sample_production/list_consumer.yml
+++ b/ansible/sample_production/list_consumer.yml
@@ -1,0 +1,47 @@
+---
+- hosts: localhost
+
+  tasks:
+  - include_vars: group_vars/consumer.yml
+  - set_fact:
+      tenants_dict: {}
+
+  - name: Get tenants
+    purestorage.fusion.fusion_info:
+      app_id: "{{ api_client }}"
+      key_file: "{{ priv_key_file }}"
+      gather_subset: tenants
+    register: fusion_info
+  - debug: msg="{{ fusion_info['fusion_info'] }}"
+  
+  - name: Get tenant_spaces
+    purestorage.fusion.fusion_info:
+      app_id: "{{ api_client }}"
+      key_file: "{{ priv_key_file }}"
+      gather_subset: tenant_spaces
+    register: fusion_info
+  - debug: msg="{{ fusion_info['fusion_info'] }}"
+
+  - name: Collect api_clients from Pure Storage
+    purestorage.fusion.fusion_info:
+      gather_subset: api_clients
+      app_id: "{{ ansible_env.API_CLIENT }}"
+      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+    register: fusion_info
+  - debug: msg="{{ fusion_info['fusion_info'] }}"
+
+  - name: Collect Roles from Pure Storage
+    purestorage.fusion.fusion_info:
+      gather_subset: roles
+      app_id: "{{ ansible_env.API_CLIENT }}"
+      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+    register: fusion_info
+  - debug: msg="{{ fusion_info['fusion_info'] }}"
+
+  - name: Collect Users from Pure Storage
+    purestorage.fusion.fusion_info:
+      gather_subset: users
+      app_id: "{{ ansible_env.API_CLIENT }}"
+      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+    register: fusion_info
+  - debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/sample_production/setup_consumer.yml
+++ b/ansible/sample_production/setup_consumer.yml
@@ -1,0 +1,91 @@
+---
+- hosts: localhost
+
+  tasks:
+    - include_vars: group_vars/consumer.yml
+    - set_fact:
+        tenants_dict: {}
+
+    - name: Check private key exists
+      stat:
+        path: "{{ ansible_env.PRIV_KEY_FILE}}"
+      register: result
+
+    - name: End run if missing private key
+      meta: end_play
+      when: (result.stat.isreg is undefined) or (not result.stat.isreg)
+
+    - name: "Creates work directory {{workdir}}"
+      file:
+        path: "{{workdir}}"
+        state: directory
+
+    - name: "Creates tenants folders"
+      file:
+        path: "{{workdir}}/{{ item.name }}"
+        state: directory
+      loop: "{{ tenants }}"
+
+    - name: Create new tenant(s)
+      purestorage.fusion.fusion_tenant:
+        app_id: "{{ ansible_env.API_CLIENT}}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
+        state: present # or absent
+        name: "{{ item.name }}"
+        display_name: "{{ item.display_name }}"
+      loop: "{{ tenants }}"
+
+    - name: Create a Private RSA key
+      community.crypto.openssl_privatekey:
+        path: "{{workdir}}/{{item.name}}/priv_{{item.name}}.pem"
+        type: RSA
+        size: "{{key_size}}"
+      loop: "{{ tenants }}"
+
+    - name: Create a Public RSA key
+      community.crypto.openssl_publickey:
+        path: "{{workdir}}/{{item.name}}/pub_{{item.name}}.pem"
+        privatekey_path: "{{workdir}}/{{item.name}}/priv_{{item.name}}.pem"
+      loop: "{{ tenants }}"
+
+    - name: Create new API client foo
+      purestorage.fusion.fusion_api_client:
+        app_id: "{{ ansible_env.API_CLIENT}}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"  
+        state: present
+        name: "{{ item.name }}"
+        public_key: "{{lookup('file', workdir + '/' + item.name + '/pub_' + item.name + '.pem') }}"
+      loop: "{{ tenants }}"
+
+    - name: Convert Tenant list to dict
+      set_fact:
+        tenants_dict: "{{ tenants_dict|combine( {item.name: item.display_name} ) }}"
+      with_items:
+          - "{{ tenants }}"
+
+    - name: Collect Api Clients 
+      purestorage.fusion.fusion_info:
+        gather_subset: api_clients
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
+
+    - name: Creating a file .iss in tenant folder 
+      copy:
+        dest: "{{workdir}}/{{item.value.display_name}}/{{item.value.display_name}}.iss"
+        content: "{{ item.value.issuer }}"
+      with_dict: "{{ fusion_info['fusion_info']['api_clients'] }}"
+      when: item.value.display_name in tenants_dict.keys()
+    
+    - name: Role Assignment to Tenant(s)
+      purestorage.fusion.fusion_ra:
+        app_id: "{{ ansible_env.API_CLIENT}}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"  
+        state: present
+        name: "tenant-admin" 
+        scope: "tenant"  # "organization" "tenant_space"
+        tenant: "{{ item.value.display_name }}"
+        user: "{{item.value.issuer}}"
+      with_dict: "{{ fusion_info['fusion_info']['api_clients'] }}"
+      when: item.value.display_name in tenants_dict.keys()
+      

--- a/ansible/sample_production/teardown_consumer.yml
+++ b/ansible/sample_production/teardown_consumer.yml
@@ -1,0 +1,56 @@
+---
+- hosts: localhost
+
+  tasks:
+    - include_vars: group_vars/consumer.yml
+    - set_fact:
+        tenants_dict: {}
+
+    - name: Convert Tenant list to dict
+      set_fact:
+        tenants_dict: "{{ tenants_dict|combine( {item.name: item.display_name} ) }}"
+      with_items:
+          - "{{ tenants }}"
+
+    - name: Collect Api Clients 
+      purestorage.fusion.fusion_info:
+        gather_subset: api_clients
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
+      
+    - name: Delete Role Assignment to Tenant(s)
+      purestorage.fusion.fusion_ra:
+        app_id: "{{ ansible_env.API_CLIENT}}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"  
+        state: absent
+        name: "tenant-admin" 
+        scope: "tenant"  # "organization" "tenant_space"
+        tenant: "{{ item.value.display_name }}"
+        user: "{{item.value.issuer}}"
+      with_dict: "{{ fusion_info['fusion_info']['api_clients'] }}"
+      when: item.value.display_name in tenants_dict.keys()
+
+    - name: Delete API clients 
+      purestorage.fusion.fusion_api_client:
+        app_id: "{{ ansible_env.API_CLIENT}}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"  
+        state: absent
+        name: "{{ item.name }}"
+        public_key: "{{lookup('file', workdir + '/' + item.name + '/pub_' + item.name + '.pem') }}"
+      loop: "{{ tenants }}"
+
+    - name: Delete Tenants
+      purestorage.fusion.fusion_tenant:
+        app_id: "{{ ansible_env.API_CLIENT}}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
+        state: absent
+        name: "{{ item.name }}"
+      loop: "{{ tenants }}"
+
+    - name: Delete Tenants directory
+      file:
+        state: absent
+        path: "{{workdir}}/{{item.name}}"
+      loop: "{{ tenants }}"
+


### PR DESCRIPTION
Want playbook(s) that can manage consumer onboarding.

Workflows involved:
    Generating new APIkey for either provider or consumer.
    Granting existing APIkey(s) access to existing Tenant(s) and/or Tenant-space(s)
    Creating new Tenant(s) and granting new or existing APIkey(s) access to Tenant

