### PR TITLE
Rename Tenant Networks to Storage Endpoints

### DIFF
--- a/ansible/sample_production/group_vars/infrastructure.yml
+++ b/ansible/sample_production/group_vars/infrastructure.yml
@@ -5,6 +5,7 @@ regions:
 availability_zones:
   - name: az1
     display_name: az1
+    region: region1
 
 network_interface_groups:
   - name: interface_group1
@@ -24,6 +25,7 @@ storage_endpoints:
     gateway: 172.17.1.1
     network_interface_groups: ["interface_group1"]
     availability_zone: az1
+    region: "region1"
 
 arrays:
   - name: flasharray1

--- a/ansible/sample_production/setup_infrastructure.yml
+++ b/ansible/sample_production/setup_infrastructure.yml
@@ -28,6 +28,7 @@
       state: present # or absent
       name: "{{ item.name }}"
       display_name: "{{ item.display_name }}"
+      region: "{{ item.region }}"
     loop: "{{ availability_zones }}"
 
   - name: Create new network interface group(s)
@@ -53,10 +54,10 @@
       name: "{{ item.name }}"
       display_name: "{{ item.display_name }}"
       availability_zone: "{{ item.availability_zone }}"
-      mtu: "{{ item.mtu }}"
       gateway: "{{ item.gateway }}"
       addresses: "{{ item.address }}"
-      provider_subnets: "{{ item.network_interface_groups }}"
+      region: "{{ item.region }}"
+      network_interface_groups: "{{ item.network_interface_groups }}"
     loop: "{{ storage_endpoints }}"
 
   - name: Create new array(s)


### PR DESCRIPTION
Translates the rename of tenant networks to storage endpoints in underlying Python SDK into here.
This is coupled with a commit into Pure-Storage-Ansible/Fusion-Collection.

Fixes internal issue HM-4757.