### PR TITLE
Add configurable host and token endpoints

### DIFF
--- a/python/00_smoke_test.py
+++ b/python/00_smoke_test.py
@@ -7,6 +7,10 @@ from os import getenv
 def smoke_test():
     # Configure OAuth2 access token for authorization
     configuration = fusion.Configuration()
+    if getenv('HOST_ENDPOINT'):
+        configuration.host = getenv('HOST_ENDPOINT')
+    if getenv('TOKEN_ENDPOINT'):
+        configuration.token_endpoint = getenv('TOKEN_ENDPOINT')
     configuration.issuer_id = getenv('API_CLIENT')
     configuration.private_key_file = getenv('PRIV_KEY_FILE')
 

--- a/python/01_setup_infrastructure.py
+++ b/python/01_setup_infrastructure.py
@@ -10,6 +10,10 @@ def setup_infrastructure():
     print("Setting up infrastructure")
     # Setup Config
     config = fusion.Configuration()
+    if os.getenv('HOST_ENDPOINT'):
+        config.host = os.getenv('HOST_ENDPOINT')
+    if os.getenv('TOKEN_ENDPOINT'):
+        config.token_endpoint = os.getenv('TOKEN_ENDPOINT')
     config.issuer_id = os.getenv("API_CLIENT")
     config.private_key_file = os.getenv("PRIV_KEY_FILE")
 

--- a/python/02_setup_storage_policies.py
+++ b/python/02_setup_storage_policies.py
@@ -10,6 +10,10 @@ def setup_storage_policies():
     print("Setting up storage policies")
     # Setup Config
     config = fusion.Configuration()
+    if os.getenv('HOST_ENDPOINT'):
+        config.host = os.getenv('HOST_ENDPOINT')
+    if os.getenv('TOKEN_ENDPOINT'):
+        config.token_endpoint = os.getenv('TOKEN_ENDPOINT')
     config.issuer_id = os.getenv("API_CLIENT")
     config.private_key_file = os.getenv("PRIV_KEY_FILE")
 

--- a/python/03_setup_protection_policies.py
+++ b/python/03_setup_protection_policies.py
@@ -10,6 +10,10 @@ def setup_protection_policies():
     print("Setting up protection policies")
     # Setup Config
     config = fusion.Configuration()
+    if os.getenv('HOST_ENDPOINT'):
+        config.host = os.getenv('HOST_ENDPOINT')
+    if os.getenv('TOKEN_ENDPOINT'):
+        config.token_endpoint = os.getenv('TOKEN_ENDPOINT')
     config.issuer_id = os.getenv("API_CLIENT")
     config.private_key_file = os.getenv("PRIV_KEY_FILE")
 

--- a/python/04_setup_tenants.py
+++ b/python/04_setup_tenants.py
@@ -9,6 +9,10 @@ def setup_tenants():
     print("Setting up tenants")
     # Setup Config
     config = fusion.Configuration()
+    if os.getenv('HOST_ENDPOINT'):
+        config.host = os.getenv('HOST_ENDPOINT')
+    if os.getenv('TOKEN_ENDPOINT'):
+        config.token_endpoint = os.getenv('TOKEN_ENDPOINT')
     config.issuer_id = os.getenv("API_CLIENT")
     config.private_key_file = os.getenv("PRIV_KEY_FILE")
 

--- a/python/05_setup_workloads.py
+++ b/python/05_setup_workloads.py
@@ -10,6 +10,10 @@ def setup_workloads():
     print("Setting up workloads")
     # Setup Config
     config = fusion.Configuration()
+    if os.getenv('HOST_ENDPOINT'):
+        config.host = os.getenv('HOST_ENDPOINT')
+    if os.getenv('TOKEN_ENDPOINT'):
+        config.token_endpoint = os.getenv('TOKEN_ENDPOINT')
     config.issuer_id = os.getenv("API_CLIENT")
     config.private_key_file = os.getenv("PRIV_KEY_FILE")
 

--- a/python/06_teardown_workloads.py
+++ b/python/06_teardown_workloads.py
@@ -8,6 +8,10 @@ def teardown_workloads():
     print("Tearing down workloads")
     # Setup Config
     config = fusion.Configuration()
+    if os.getenv('HOST_ENDPOINT'):
+        config.host = os.getenv('HOST_ENDPOINT')
+    if os.getenv('TOKEN_ENDPOINT'):
+        config.token_endpoint = os.getenv('TOKEN_ENDPOINT')
     config.issuer_id = os.getenv("API_CLIENT")
     config.private_key_file = os.getenv("PRIV_KEY_FILE")
 

--- a/python/07_teardown_tenants.py
+++ b/python/07_teardown_tenants.py
@@ -1,5 +1,6 @@
 import fusion
 import os
+from fusion.rest import ApiException
 from pprint import pprint
 from utils import wait_operation_succeeded
 
@@ -7,6 +8,10 @@ def teardown_tenants():
     print("Tearing down tenants")
     # Setup Config
     config = fusion.Configuration()
+    if os.getenv('HOST_ENDPOINT'):
+        config.host = os.getenv('HOST_ENDPOINT')
+    if os.getenv('TOKEN_ENDPOINT'):
+        config.token_endpoint = os.getenv('TOKEN_ENDPOINT')
     config.issuer_id = os.getenv("API_CLIENT")
     config.private_key_file = os.getenv("PRIV_KEY_FILE")
 

--- a/python/08_teardown_protection_policies.py
+++ b/python/08_teardown_protection_policies.py
@@ -8,6 +8,10 @@ def teardown_protection_policies():
     print("Tearing down protection policies")
     # Setup Config
     config = fusion.Configuration()
+    if os.getenv('HOST_ENDPOINT'):
+        config.host = os.getenv('HOST_ENDPOINT')
+    if os.getenv('TOKEN_ENDPOINT'):
+        config.token_endpoint = os.getenv('TOKEN_ENDPOINT')
     config.issuer_id = os.getenv("API_CLIENT")
     config.private_key_file = os.getenv("PRIV_KEY_FILE")
 

--- a/python/09_teardown_storage_policies.py
+++ b/python/09_teardown_storage_policies.py
@@ -8,6 +8,10 @@ def teardown_storage_policies():
     print("Tearing down storage policies")
     # Setup Config
     config = fusion.Configuration()
+    if os.getenv('HOST_ENDPOINT'):
+        config.host = os.getenv('HOST_ENDPOINT')
+    if os.getenv('TOKEN_ENDPOINT'):
+        config.token_endpoint = os.getenv('TOKEN_ENDPOINT')
     config.issuer_id = os.getenv("API_CLIENT")
     config.private_key_file = os.getenv("PRIV_KEY_FILE")
 

--- a/python/10_teardown_infrastructure.py
+++ b/python/10_teardown_infrastructure.py
@@ -8,6 +8,10 @@ def teardown_infrastructure():
     print("Tearing down infrastructure")
     # Setup Config
     config = fusion.Configuration()
+    if os.getenv('HOST_ENDPOINT'):
+        config.host = os.getenv('HOST_ENDPOINT')
+    if os.getenv('TOKEN_ENDPOINT'):
+        config.token_endpoint = os.getenv('TOKEN_ENDPOINT')
     config.issuer_id = os.getenv("API_CLIENT")
     config.private_key_file = os.getenv("PRIV_KEY_FILE")
 


### PR DESCRIPTION
This PR adds possibility to read env variables for host and token services in python scripts. So if you want to test python scripts in local environment, you can specify `HOST_ENDPOINT` and `TOKEN_ENDPOINT` env vars.